### PR TITLE
Add user service URL support and refactor axios instances

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,12 @@ WORKDIR /app
 # Aceptar argumento de construcción para la variable de entorno
 ARG REACT_APP_BASE_URL
 
+ARG REACT_APP_USER_SERVICE_URL
+
 # Configurar la variable de entorno para la compilación de React
 ENV REACT_APP_BASE_URL=$REACT_APP_BASE_URL
+
+ENV REACT_APP_USER_SERVICE_URL=$REACT_APP_USER_SERVICE_URL
 
 # Copiar archivos de configuración
 COPY package*.json tsconfig.json ./

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -25,6 +25,8 @@ steps:
           - '$_AR_HOSTNAME/$_PROJECT_ID/$_AR_REPO/$_SERVICE_NAME:$COMMIT_SHA'
           - '--build-arg'
           - 'REACT_APP_BASE_URL=$_REACT_APP_BASE_URL'
+          - '--build-arg'
+          - 'REACT_APP_USER_SERVICE_URL=$_REACT_APP_USER_SERVICE_URL'
           - './'
 
     - id: push

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,6 +6,7 @@ services:
             target: production
             args:
                 REACT_APP_BASE_URL: ${REACT_APP_BASE_URL}
+                REACT_APP_USER_SERVICE_URL: ${REACT_APP_USER_SERVICE_URL}
         container_name: ${DOCKER_SERVICE_NAME}
         volumes:
             - ./src:/app/src

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.13.3",
         "@emotion/styled": "^11.13.0",
-        "@mui/icons-material": "^6.1.6",
+        "@mui/icons-material": "^6.1.5",
         "@mui/material": "^6.1.4",
         "@testing-library/react": "^16.0.1",
         "@testing-library/user-event": "^13.5.0",
@@ -28,9 +28,10 @@
         "@babel/preset-env": "^7.25.8",
         "@babel/preset-react": "^7.25.7",
         "@babel/preset-typescript": "^7.25.7",
-        "@testing-library/jest-dom": "^6.6.2",
+        "@testing-library/jest-dom": "^6.6.3",
         "@types/jest": "^29.5.13",
         "@types/react": "^18.3.12",
+        "axios-mock-adapter": "^2.1.0",
         "babel-jest": "^29.7.0",
         "gts": "^3.1.0",
         "jest": "^29.7.0",
@@ -4179,9 +4180,9 @@
       }
     },
     "node_modules/@testing-library/jest-dom": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.6.2.tgz",
-      "integrity": "sha512-P6GJD4yqc9jZLbe98j/EkyQDTPgqftohZF5FBkHY5BUERZmcf4HeO2k0XaefEg329ux2p21i1A1DmyQ1kKw2Jw==",
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.6.3.tgz",
+      "integrity": "sha512-IteBhl4XqYNkM54f4ejhLRJiZNqcSCoXUOG2CPK7qbD322KjQozM4kHQOfkG2oln9b9HTYqs+Sae8vBATubxxA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5700,6 +5701,20 @@
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios-mock-adapter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-2.1.0.tgz",
+      "integrity": "sha512-AZUe4OjECGCNNssH8SOdtneiQELsqTsat3SQQCWLPjN436/H+L9AjWfV7bF+Zg/YL9cgbhrz5671hoh+Tbn98w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "is-buffer": "^2.0.5"
+      },
+      "peerDependencies": {
+        "axios": ">= 0.17.0"
       }
     },
     "node_modules/axobject-query": {
@@ -11544,6 +11559,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/is-callable": {
@@ -26162,9 +26201,9 @@
       }
     },
     "@testing-library/jest-dom": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.6.2.tgz",
-      "integrity": "sha512-P6GJD4yqc9jZLbe98j/EkyQDTPgqftohZF5FBkHY5BUERZmcf4HeO2k0XaefEg329ux2p21i1A1DmyQ1kKw2Jw==",
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.6.3.tgz",
+      "integrity": "sha512-IteBhl4XqYNkM54f4ejhLRJiZNqcSCoXUOG2CPK7qbD322KjQozM4kHQOfkG2oln9b9HTYqs+Sae8vBATubxxA==",
       "dev": true,
       "requires": {
         "@adobe/css-tools": "^4.4.0",
@@ -27333,6 +27372,16 @@
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
+      }
+    },
+    "axios-mock-adapter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-2.1.0.tgz",
+      "integrity": "sha512-AZUe4OjECGCNNssH8SOdtneiQELsqTsat3SQQCWLPjN436/H+L9AjWfV7bF+Zg/YL9cgbhrz5671hoh+Tbn98w==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.3",
+        "is-buffer": "^2.0.5"
       }
     },
     "axobject-query": {
@@ -31451,6 +31500,12 @@
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
       }
+    },
+    "is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "dev": true
     },
     "is-callable": {
       "version": "1.2.7",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@types/jest": "^29.5.13",
     "@types/react": "^18.3.12",
+    "axios-mock-adapter": "^2.1.0",
     "babel-jest": "^29.7.0",
     "gts": "^3.1.0",
     "jest": "^29.7.0",

--- a/src/pages/LoginClient/LoginClient.tsx
+++ b/src/pages/LoginClient/LoginClient.tsx
@@ -22,7 +22,7 @@ const LoginClient: React.FC = () => {
         setErrorMessage(null);
         try {
             const response = await axiosInstance.post('/login-client', formData);
-            const token = response.data.token;
+            const token = response.data.access_token;
             login(token);
             navigate('/dashboard');
         } catch (error) {

--- a/src/pages/UserSync/UserSync.test.tsx
+++ b/src/pages/UserSync/UserSync.test.tsx
@@ -2,10 +2,16 @@ import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import axiosInstance from '../../utils/axiosInstance';
+import axiosUserServiceInstance from '../../utils/axiosUserServiceInstance';
 import UserSync from './UserSync';
 
 jest.mock('../../utils/axiosInstance');
 const mockAxiosInstance = axiosInstance as jest.Mocked<typeof axiosInstance>;
+
+jest.mock('../../utils/axiosUserServiceInstance');
+const mockAxiosUserServiceInstance = axiosUserServiceInstance as jest.Mocked<
+    typeof axiosUserServiceInstance
+>;
 
 describe('UserSync Component', () => {
     beforeEach(() => {
@@ -59,7 +65,7 @@ describe('UserSync Component', () => {
     });
 
     test('uploads file successfully', async () => {
-        mockAxiosInstance.post.mockResolvedValue({ data: {} });
+        mockAxiosUserServiceInstance.post.mockResolvedValue({ data: {} });
 
         render(<UserSync />);
 
@@ -80,7 +86,7 @@ describe('UserSync Component', () => {
     });
 
     test('displays error message when upload fails', async () => {
-        mockAxiosInstance.post.mockRejectedValue(
+        mockAxiosUserServiceInstance.post.mockRejectedValue(
             new Error('Error al subir el archivo')
         );
 

--- a/src/pages/UserSync/UserSync.tsx
+++ b/src/pages/UserSync/UserSync.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import axiosInstance from '../../utils/axiosInstance';
+import axiosUserServiceInstance from '../../utils/axiosUserServiceInstance';
 import './UserSync.css';
 import CloudUploadIcon from '@mui/icons-material/CloudUpload';
 
@@ -36,7 +36,7 @@ const UserSync: React.FC = () => {
 
         try {
             setUploadStatus('Subiendo...');
-            await axiosInstance.post('/sync-users', formData, {
+            await axiosUserServiceInstance.post('/sync-users', formData, {
                 headers: {
                     'Content-Type': 'multipart/form-data',
                 },

--- a/src/utils/axiosInstance.test.ts
+++ b/src/utils/axiosInstance.test.ts
@@ -1,0 +1,42 @@
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import axiosInstance from './axiosInstance';
+
+describe('axiosInstance', () => {
+    let mock: MockAdapter;
+
+    beforeEach(() => {
+        mock = new MockAdapter(axiosInstance);
+    });
+
+    afterEach(() => {
+        mock.restore();
+    });
+
+    it('should include Authorization header if token is present', async () => {
+        const token = 'test-token';
+        localStorage.setItem('token', token);
+
+        mock.onGet('/test').reply(200);
+
+        await axiosInstance.get('/test');
+
+        expect(mock.history.get[0].headers?.Authorization).toBe(`Bearer ${token}`);
+    });
+
+    it('should not include Authorization header if token is not present', async () => {
+        localStorage.removeItem('token');
+
+        mock.onGet('/test').reply(200);
+
+        await axiosInstance.get('/test');
+
+        expect(mock.history.get[0].headers?.Authorization).toBeUndefined();
+    });
+
+    it('should handle request errors', async () => {
+        mock.onGet('/test').networkError();
+
+        await expect(axiosInstance.get('/test')).rejects.toThrow('Network Error');
+    });
+});

--- a/src/utils/axiosUserServiceInstance.test.ts
+++ b/src/utils/axiosUserServiceInstance.test.ts
@@ -1,0 +1,42 @@
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import axiosUserServiceInstance from './axiosUserServiceInstance';
+
+describe('axiosUserServiceInstance', () => {
+    let mock: MockAdapter;
+
+    beforeEach(() => {
+        mock = new MockAdapter(axiosUserServiceInstance);
+    });
+
+    afterEach(() => {
+        mock.restore();
+    });
+
+    it('should include Authorization header if token is present', async () => {
+        const token = 'test-token';
+        localStorage.setItem('token', token);
+
+        mock.onGet('/test').reply(200);
+
+        await axiosUserServiceInstance.get('/test');
+
+        expect(mock.history.get[0].headers?.Authorization).toBe(`Bearer ${token}`);
+    });
+
+    it('should not include Authorization header if token is not present', async () => {
+        localStorage.removeItem('token');
+
+        mock.onGet('/test').reply(200);
+
+        await axiosUserServiceInstance.get('/test');
+
+        expect(mock.history.get[0].headers?.Authorization).toBeUndefined();
+    });
+
+    it('should handle request errors', async () => {
+        mock.onGet('/test').networkError();
+
+        await expect(axiosUserServiceInstance.get('/test')).rejects.toThrow('Network Error');
+    });
+});

--- a/src/utils/axiosUserServiceInstance.ts
+++ b/src/utils/axiosUserServiceInstance.ts
@@ -1,16 +1,15 @@
 import axios from 'axios';
 
-const axiosInstance = axios.create({
-    baseURL: process.env.REACT_APP_BASE_URL || 'https://front-abcall-345518488840.us-central1.run.app/v1',
+const axiosUserServiceInstance = axios.create({
+    baseURL: process.env.REACT_APP_USER_SERVICE_URL || 'https://user-service-url.com/v1',
     headers: {
         'Content-Type': 'application/json',
     },
 });
 
-axiosInstance.interceptors.request.use(
+axiosUserServiceInstance.interceptors.request.use(
     (config) => {
         const token = localStorage.getItem('token');
-        console.log('token', token);
         if (token) {
             config.headers.Authorization = `Bearer ${token}`;
         }
@@ -21,4 +20,4 @@ axiosInstance.interceptors.request.use(
     }
 );
 
-export default axiosInstance;
+export default axiosUserServiceInstance;


### PR DESCRIPTION
- Introduce REACT_APP_USER_SERVICE_URL in Dockerfile and docker-compose.yaml
- Update cloudbuild.yaml to pass user service URL as build argument
- Refactor LoginClient to use access_token from login response
- Replace axiosInstance with axiosUserServiceInstance in UserSync for user-related API calls
- Add new axiosUserServiceInstance for user service interactions
- Log token in axiosInstance for debugging purposes